### PR TITLE
added version support for rebing/graphql-laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "license": "MIT",
     "require": {
-        "rebing/graphql-laravel": "^1.12"
+        "rebing/graphql-laravel": "^1.12|^2.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Uroshcs/GraphQLQueryDebugger/GraphQL/QueriesExecutedQuery.php
+++ b/src/Uroshcs/GraphQLQueryDebugger/GraphQL/QueriesExecutedQuery.php
@@ -3,7 +3,7 @@
 namespace Uroshcs\GraphQLQueryDebugger\GraphQL;
 
 use GraphQL\Type\Definition\Type;
-use GraphQL;
+use Rebing\GraphQL\Support\Facades\GraphQL;
 use Rebing\GraphQL\Support\Query;
 
 class QueriesExecutedQuery extends Query

--- a/src/Uroshcs/GraphQLQueryDebugger/GraphQL/QueriesExecutedQuery.php
+++ b/src/Uroshcs/GraphQLQueryDebugger/GraphQL/QueriesExecutedQuery.php
@@ -12,7 +12,7 @@ class QueriesExecutedQuery extends Query
         'name' => 'Queries executed',
     ];
 
-    public function type()
+    public function type() :Type
     {
         return Type::listOf(GraphQL::type('query_executed'));
     }

--- a/src/Uroshcs/GraphQLQueryDebugger/GraphQL/QueryExecutedType.php
+++ b/src/Uroshcs/GraphQLQueryDebugger/GraphQL/QueryExecutedType.php
@@ -12,7 +12,7 @@ class QueryExecutedType extends GraphQLType
         'description' => 'An executed query',
     ];
 
-    public function fields()
+    public function fields() :array
     {
         return [
             'sql' => [


### PR DESCRIPTION
These changes tested for support `rebing/graphql: ^2.0 `versions and works fine.
other versions (0.*, 1.*) versions are not tested